### PR TITLE
47 linter actions

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -7,6 +7,16 @@ on:
     branches: [ "main" ]
 
 jobs:
+  run-checker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - run: sudo apt-get install -y splint
+
+    - run: ./checker
+
   build-minimal:
     runs-on: ubuntu-latest
 

--- a/board/common-arcade/post-build.sh
+++ b/board/common-arcade/post-build.sh
@@ -3,6 +3,6 @@
 set -u
 set -e
 
-BOARD_DIR="$(dirname $0)"
+BOARD_DIR="$(dirname "$0")"
 
-cp -r ${BOARD_DIR}/custom-skeleton/ ${TARGET_DIR}
+cp -r "${BOARD_DIR}"/custom-skeleton/ "${TARGET_DIR}"

--- a/board/raspberrypi4-arcade/post-build.sh
+++ b/board/raspberrypi4-arcade/post-build.sh
@@ -3,19 +3,19 @@
 set -u
 set -e
 
-BOARD_DIR="$(dirname $0)"
+BOARD_DIR="$(dirname "$0")"
 
 # Execute common first
-${BOARD_DIR}/../common-arcade/post-build.sh
+"${BOARD_DIR}"/../common-arcade/post-build.sh
 
 # Add a console on tty1
-if [ -e ${TARGET_DIR}/etc/inittab ]; then
-    grep -qE '^tty1::' ${TARGET_DIR}/etc/inittab || \
+if [ -e "${TARGET_DIR}"/etc/inittab ]; then
+    grep -qE '^tty1::' "${TARGET_DIR}"/etc/inittab || \
 	sed -i '/GENERIC_SERIAL/a\
-tty1::respawn:/sbin/getty -L  tty1 0 vt100 # HDMI console' ${TARGET_DIR}/etc/inittab
+tty1::respawn:/sbin/getty -L  tty1 0 vt100 # HDMI console' "${TARGET_DIR}"/etc/inittab
 fi
 
 # ensure overlays exists for genimage
-mkdir -p "${BINARIES_DIR}/rpi-firmware/overlays"
+mkdir -p "${BINARIES_DIR}"/rpi-firmware/overlays
 
-cp -r ${BOARD_DIR}/custom-skeleton/ ${TARGET_DIR}
+cp -r "${BOARD_DIR}"/custom-skeleton/ "${TARGET_DIR}"

--- a/board/raspberrypi4-arcade/post-image.sh
+++ b/board/raspberrypi4-arcade/post-image.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-BOARD_DIR="$(dirname $0)"
-GENIMAGE_CFG="${BOARD_DIR}/genimage.cfg"
-GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BOARD_DIR="$(dirname "$0")"
+GENIMAGE_CFG="${BOARD_DIR}"/genimage.cfg
+GENIMAGE_TMP="${BUILD_DIR}"/genimage.tmp
 
 # Pass an empty rootpath. genimage makes a full copy of the given rootpath to
 # ${GENIMAGE_TMP}/root so passing TARGET_DIR would be a waste of time and disk

--- a/builder
+++ b/builder
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 TARGET_LIST=("rpi4-arcade-min" "rpi4-arcade" "rpi4-arcade-dev")
-TARGET_BOARD=$2
+TARGET_BOARD="$2"
 mkdir -p "${PWD}/../builds/"
 SETUP_DIR="${PWD}"
-BUILD_DIR="$(builtin cd "${PWD}/../builds/"; pwd)"
+BUILD_DIR="$(builtin cd "${PWD}/../builds/" || exit 1; pwd)"
 BUILDROOT_VERSION="buildroot-2023.02.3"
 STANDALONE=FALSE
 if [[ "$3" == "stand-alone" ]]; then
@@ -19,27 +19,29 @@ usage() {
 }
 
 move_dir() {
-	local MOVEDIR=$1
+	local MOVEDIR="$1"
 	if [[ "${STANDALONE}" == "TRUE" ]]; then
-		cp -r ${SETUP_DIR}/${MOVEDIR}/* ${BUILD_TARGET_DIR}/${MOVEDIR}/
+		cp -r "${SETUP_DIR}/${MOVEDIR}/*" "${BUILD_TARGET_DIR}/${MOVEDIR}/"
 	else
-		for package in ${SETUP_DIR}/${MOVEDIR}/*; do
-			rm -rf ${BUILD_TARGET_DIR}/${MOVEDIR}/${package##*/}
-			ln -s $package ${BUILD_TARGET_DIR}/${MOVEDIR}/${package##*/}
+		for package in "${SETUP_DIR:?}/${MOVEDIR}"/*; do
+			rm -rf "${BUILD_TARGET_DIR:?}/${MOVEDIR}/${package##*/}"
+			ln -s "$package" "${BUILD_TARGET_DIR}/${MOVEDIR}/${package##*/}"
 		done
 	fi
 }
 
 verify_board() {
 	echo "Verifying validity of target..."
-	if ! [[ " ${TARGET_LIST[@]} " =~ " ${TARGET_BOARD} "  ]]; then
+	if ! [[ " ${TARGET_LIST[*]} " =~ ${TARGET_BOARD}  ]]; then
 		usage
 		exit 1
 	fi
 }
 
 setup() {
-	local BUILD_TARGET_DIR=${BUILD_DIR}/${TARGET_BOARD}
+	local BUILD_TARGET_DIR="${BUILD_DIR}/${TARGET_BOARD}"
+	# Ensure build directory exists
+	mkdir -p "${BUILD_DIR}"
 
 	local CONFIG_FILE="configs/${TARGET_BOARD}.buildercfg"
 	if [ ! -f "${CONFIG_FILE}" ]; then
@@ -47,29 +49,34 @@ setup() {
 	fi
 
 	echo "Setting up buildroot environment..."
-	local BUILDROOT_DIR=${BUILD_DIR}/${BUILDROOT_VERSION}
+	local BUILDROOT_DIR="${BUILD_DIR}/${BUILDROOT_VERSION}"
 	if [ ! -d "${BUILDROOT_DIR}" ]; then
-		local FILE_NAME=${BUILDROOT_DIR}.tar.gz
-		wget -O ${FILE_NAME} https://buildroot.org/downloads/${BUILDROOT_VERSION}.tar.gz
-		cd ${BUILD_DIR}
-		tar xvzf ${FILE_NAME}
-		rm -rf ${FILE_NAME}
+		local FILE_NAME="${BUILDROOT_DIR}.tar.gz"
+		wget -O "${FILE_NAME}" "https://buildroot.org/downloads/${BUILDROOT_VERSION}.tar.gz"
+		cd "${BUILD_DIR}" || exit 1
+		tar xvzf "${FILE_NAME}"
+		rm -rf "${FILE_NAME}"
 	fi
 	if [ ! -d "${BUILD_TARGET_DIR}" ]; then
-		cp -r ${BUILDROOT_DIR} ${BUILD_TARGET_DIR}
+		cp -r "${BUILDROOT_DIR}" "${BUILD_TARGET_DIR}"
 	fi
 
 	echo "Moving packages..."
 	local CONFIG_IN_FILE=${BUILD_TARGET_DIR}/Config.in
-	local CONFIG_IN_CUSTOM=${BUILD_TARGET_DIR}/package/Config.in.custom
+	local CONFIG_IN_CUSTOM="${BUILD_TARGET_DIR}/package/Config.in.custom"
 	move_dir package
-	rm -rf ${CONFIG_IN_CUSTOM}
-	touch ${CONFIG_IN_CUSTOM}
-	echo "menu \"Custom Packages\"" >> ${CONFIG_IN_CUSTOM}
-	find package -name 'Config.in' -exec echo -e "\tsource \"{}\"" >> ${CONFIG_IN_CUSTOM} \;
-	echo "endmenu" >> ${CONFIG_IN_CUSTOM}
-	if ! grep -q "Config.in.custom" ${CONFIG_IN_FILE}; then
-		echo -e 'source "package/Config.in.custom"' >> $CONFIG_IN_FILE
+	rm -rf "${CONFIG_IN_CUSTOM}"
+	touch "${CONFIG_IN_CUSTOM}"
+	# shellcheck disable=SC2129
+	echo "menu \"Custom Packages\"" >> "${CONFIG_IN_CUSTOM}"
+	# Ignoring this warning because it is wrong, the redirection is being
+	# applied to the echo, not the find command. Creating a follow on issue
+	# to look into this further. Issue number 48.
+	# shellcheck disable=SC2227
+	find package -name 'Config.in' -exec echo -e "\tsource \"{}\"" >> "${CONFIG_IN_CUSTOM}" \;
+	echo "endmenu" >> "${CONFIG_IN_CUSTOM}"
+	if ! grep -q "Config.in.custom" "${CONFIG_IN_FILE}"; then
+		echo -e 'source "package/Config.in.custom"' >> "$CONFIG_IN_FILE"
 	fi
 
 	echo "Moving boards..."
@@ -78,12 +85,12 @@ setup() {
 	echo "Setting up configuration file..."
 	local DEF_CONFIG_FILE_NAME="${TARGET_BOARD//-/_}_defconfig"
 	local DEF_CONFIG="${BUILD_TARGET_DIR}/configs/${DEF_CONFIG_FILE_NAME}"
-	rm -rf ${DEF_CONFIG}
-	touch ${DEF_CONFIG}
-	while read partconfig; do
-		cat partials/$partconfig >> ${DEF_CONFIG}
-	done < $CONFIG_FILE
-	cd ${BUILD_TARGET_DIR} && make ${DEF_CONFIG_FILE_NAME}
+	rm -rf "${DEF_CONFIG}"
+	touch "${DEF_CONFIG}"
+	while read -r partconfig; do
+		cat "partials/$partconfig" >> "${DEF_CONFIG}"
+	done < "$CONFIG_FILE"
+	make -C "${BUILD_TARGET_DIR}" "${DEF_CONFIG_FILE_NAME}" || exit 1
 
 	echo "Build successfully setup"
 }
@@ -91,7 +98,7 @@ setup() {
 build() {
 	setup
 	echo "Starting build..."
-	(cd ${BUILD_DIR}/${TARGET_BOARD} && make all)
+	(cd "${BUILD_DIR}/${TARGET_BOARD}" && make all)
 	echo "Build complete."
 }
 

--- a/checker
+++ b/checker
@@ -1,0 +1,22 @@
+#!/bin/bash
+# shellcheck disable=SC2044
+
+# Bash Checks
+ERROR+=$?
+shellcheck builder
+shellcheck checker
+for file in $(find . -name "*.sh"); do
+	shellcheck "$file"
+	ERROR+=$?
+done
+
+# C Checks
+for file in $(find . -name "*.c"); do
+	splint "$file"
+	ERROR+=$?
+done
+
+# Exit if there were any errors
+if ! [ "$ERROR" -eq 0 ]; then
+	exit 1
+fi

--- a/package/buildinfo/src/buildinfo.c
+++ b/package/buildinfo/src/buildinfo.c
@@ -6,4 +6,5 @@ int main() {
 	printf(" ");
 	printf(__TIME__);
 	printf("\n");
+	return 0;
 }


### PR DESCRIPTION
Adds shellcheck and splint linters and applies them to all files via the checker script. Adds checker to functionality so this is done on every build and PR.