### PR TITLE
builder: Fix checker warnings

### DIFF
--- a/builder
+++ b/builder
@@ -60,7 +60,7 @@ setup() {
 		pushd "${BUILD_DIR}" || exit 1
 		tar xvzf "${FILE_NAME}"
 		rm -rf "${FILE_NAME}"
-		popd
+		popd || exit 1
 	fi
 	if [ ! -d "${BUILD_TARGET_DIR}" ]; then
 		cp -r "${BUILDROOT_DIR}" "${BUILD_TARGET_DIR}"


### PR DESCRIPTION
popd can theoretically fail of the directory being returned to no longer exists, if that is the case we want to check for that case and fail.