### PR TITLE
checker: Fix error propagation for checker script

### DIFF
--- a/checker
+++ b/checker
@@ -2,10 +2,10 @@
 # shellcheck disable=SC2044
 
 # Bash Checks
-ERROR+=$?
 shellcheck builder
 ERROR+=$?
 shellcheck checker
+ERROR+=$?
 for file in $(find . -name "*.sh"); do
 	shellcheck "$file"
 	ERROR+=$?


### PR DESCRIPTION
Errors were displayed but not propagated to return the fail code for the actions to fail.