### PR TITLE
builder: Guarantee build directory exists

### DIFF
--- a/builder
+++ b/builder
@@ -2,11 +2,12 @@
 
 TARGET_LIST=("rpi4-arcade-min" "rpi4-arcade" "rpi4-arcade-dev")
 TARGET_BOARD="$2"
-mkdir -p "${PWD}/../builds/"
 SETUP_DIR="${PWD}"
 if [[ -z "${BUILD_DIR}" ]]; then
+	mkdir -p "${PWD}/../builds/"
 	BUILD_DIR="$(builtin cd "${PWD}/../builds/" || exit; pwd)"
 else
+	mkdir -p "${BUILD_DIR}"
 	BUILD_DIR="$(builtin cd "${BUILD_DIR}" || exit; pwd)"
 fi
 BUILDROOT_VERSION="buildroot-2023.02.3"


### PR DESCRIPTION
If a build directory is specified, make it before continuing and make the ../builds directory only if one is not specified and we are using our default location.