### PR TITLE
uboot: Undo uboot changes

### DIFF
--- a/board/raspberrypi4-arcade/config.txt
+++ b/board/raspberrypi4-arcade/config.txt
@@ -7,7 +7,7 @@
 start_file=start4.elf
 fixup_file=fixup4.dat
 
-kernel=u-boot.bin
+kernel=Image
 
 # To use an external initramfs file
 #initramfs rootfs.cpio.gz

--- a/board/raspberrypi4-arcade/genimage.cfg
+++ b/board/raspberrypi4-arcade/genimage.cfg
@@ -3,7 +3,7 @@ image boot.vfat {
 		files = {
 			"bcm2711-rpi-4-b.dtb",
 			"rpi-firmware/cmdline.txt",
-			"rpi-firmware/config.txt",
+			"../../board/raspberrypi4-arcade/config.txt",
 			"rpi-firmware/fixup4.dat",
 			"rpi-firmware/start4.elf",
 			"rpi-firmware/overlays",

--- a/partials/bootloader_partconfig
+++ b/partials/bootloader_partconfig
@@ -1,2 +1,2 @@
-BR2_TARGET_UBOOT=y
-BR2_TARGET_UBOOT_BOARD_DEFCONFIG="../../../../board/raspberrypi4-arcade/uboot"
+#BR2_TARGET_UBOOT=y
+#BR2_TARGET_UBOOT_BOARD_DEFCONFIG="../../../../board/raspberrypi4-arcade/uboot"


### PR DESCRIPTION
uboot is messed up and it is not neccessary until A/B changes are implemented, undoing for now.